### PR TITLE
Better search results when using string with spaces

### DIFF
--- a/src/query.js
+++ b/src/query.js
@@ -32,6 +32,8 @@ function multiMatch(fields, query) {
     multi_match: {
       query,
       fields,
+      type: 'most_fields',
+      operator: 'and',
       fuzziness: 'AUTO',
       prefix_length: 2
     }


### PR DESCRIPTION
Added the operator `and` inside the multi_match query for better search results when using a string with spaces. See `operator` on https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html