### PR TITLE
fix: do not export /src dir since files are packed to /lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "repository": "https://github.com/kaliberjs/elasticsearch",
   "description": "compiles .mapping.js to elasticsearch mappings and helps you query elasticsearch",
   "files": [
-    "src/**",
     "LICENSE",
     "mapping.js",
     "query.js",


### PR DESCRIPTION
## Veranderingen

<!-- Hier kun je je nieuwe features aangeven  -->
- Auto-import in vscode pakt vaak `@kaliber/elasticsearch/src/query` in plaats van `@kaliber/elasticsearch/query` wat _meerdere_ keren voor issues bij releasen heeft gezorgd. De code word `pack`'ed met `kaliber-pack`, dus `/src` exporteren als file is heel raar.

